### PR TITLE
Fix minor typo in Source Viewer

### DIFF
--- a/api-example-render.js
+++ b/api-example-render.js
@@ -499,7 +499,7 @@ class ApiExampleRender extends LitElement {
           @active-changed="${this._toggleSourceOpened}"
           ?legacy="${legacy}"
           title="Toggle between JSON and example source view"
-        >Source vierw</anypoint-button>` : undefined}
+        >Source viewer</anypoint-button>` : undefined}
     </div>`;
   }
 


### PR DESCRIPTION
This fixes a minor typo in the api-example-render file.
