### PR TITLE
[W-14588829] show examples to async a pis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-resource-example-document",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-resource-example-document",
   "description": "A viewer for examples in a resource based on AMF model",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiResourceExampleDocument.js
+++ b/src/ApiResourceExampleDocument.js
@@ -240,6 +240,10 @@ export class ApiResourceExampleDocument extends AmfHelperMixin(LitElement) {
     if (old === value) {
       return;
     }
+    // If async api, rawOnly is always false
+    // rawOnly is only used for json or xml payloads
+    // and async api payloads are not json or xml 
+    // payloads are messages with a schema
     this._rawOnly = this.isAsyncAPI ? false : value;
     this.requestUpdate('rawOnly', old);
     this._computeExamples();

--- a/src/ApiResourceExampleDocument.js
+++ b/src/ApiResourceExampleDocument.js
@@ -124,6 +124,10 @@ export class ApiResourceExampleDocument extends AmfHelperMixin(LitElement) {
     };
   }
 
+  get isAsyncAPI () {
+    return this._isAsyncAPI(this.amf)
+  } 
+
   get hasLocalStorage() {
     return this._hasLocalStorage;
   }
@@ -184,12 +188,9 @@ export class ApiResourceExampleDocument extends AmfHelperMixin(LitElement) {
    */
   set mediaType(value) {
     const old = this._mediaType;
-    if (old === value) {
-      return;
-    }
-    this._mediaType = value;
+    this._mediaType = this.isAsyncAPI && !value ? 'application/json' : value
     this.requestUpdate('mediaType', old);
-    this.isJson = this._computeIsJson(value);
+    this.isJson = this.isAsyncAPI && !value ? true : this._computeIsJson(value)
     this._computeExamples();
   }
 
@@ -239,7 +240,7 @@ export class ApiResourceExampleDocument extends AmfHelperMixin(LitElement) {
     if (old === value) {
       return;
     }
-    this._rawOnly = value;
+    this._rawOnly = this.isAsyncAPI ? false : value;
     this.requestUpdate('rawOnly', old);
     this._computeExamples();
   }


### PR DESCRIPTION
### Description

We should show payload example to ASYNC API's

Reported in: https://salesforce-internal.slack.com/archives/C4JR3FW83/p1701293742708979

Steps to reproduce:

1. Build or view in Desging center Async API Spec attached
2. Go to books/recommendations
3. Go to SUBSCRIBE
4. In the Panel Documentation not show payload example

## Result

https://github.com/advanced-rest-client/api-resource-example-document/assets/96145153/d43075ae-d564-404e-8f4d-56813790c6b2

